### PR TITLE
customization for write model filters (#27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,74 @@ These settings cause:
 
 Note the use of the **"." character** as navigational operator in both examples. It's used in order to refer to nested fields in sub documents of the record structure. The prefix at the very beginning is used as a simple convention to distinguish between the _key_ and _value_ structure of a document.
 
+### Custom Write Model Filters
+The default behaviour for the connector whenever documents are written to MongoDB collections is to make use of a proper [ReplaceOneModel](http://mongodb.github.io/mongo-java-driver/3.6/javadoc/com/mongodb/client/model/ReplaceOneModel.html) with [upsert mode](http://mongodb.github.io/mongo-java-driver/3.6/javadoc/com/mongodb/client/model/UpdateOptions.html) and **create the filter documents based on the _id field** as it is given in the value structure of the sink record.
+However, there are other use cases which need a different approach and the **customization option for generating filter documents** can support these.
+A new configuration option (_mongodb.replace.one.strategy_) allows for such customizations. Currently, the following two strategies are implemented:
+
+* **default behaviour** at.grahsl.kafka.connect.mongodb.writemodel.filter.strategy.**ReplaceOneDefaultFilterStrategy**
+* **business key** (see description of use case below) at.grahsl.kafka.connect.mongodb.writemodel.filter.strategy.**ReplaceOneBusinessKeyFilterStrategy**
+
+##### Use Case: Employing Business Keys
+Let's say you want to re-use a unique business key found in your sink records while at the same time have _BSON ObjectIds_ created for the resulting MongoDB documents.
+To achieve this a few simple configuration steps are necessary:
+
+1) make sure to **create a unique key constraint** for the business key of your target MongoDB collection
+2) use the **PartialValueStrategy** as the DocumentIdAdder's strategy in order to let the connector know which fields belong to the business key
+3) use the **ReplaceOneBusinessKeyFilterStrategy** instead of the default behaviour
+
+These configuration settings then allow to have **filter documents based on the original business key but still have _BSON ObjectIds_ created for the _id field** during the first upsert into your target MongoDB target collection.
+Find below how such a setup might look like:
+ 
+Given the following fictional Kafka record
+
+```json
+{ 
+  "fieldA": "Anonymous", 
+  "fieldB": 42,
+  "active": true, 
+  "values": [12.34, 23.45, 34.56, 45.67]
+}
+```
+
+together with the sink connector config below 
+
+```json
+{
+  "name": "mdb-sink",
+  "config": {
+    "key.converter":"org.apache.kafka.connect.json.JsonConverter",
+    "key.converter.schemas.enable": false,
+    "value.converter":"org.apache.kafka.connect.json.JsonConverter",
+    "value.converter.schemas.enable": false,
+    "connector.class": "at.grahsl.kafka.connect.mongodb.MongoDbSinkConnector",
+    "topics": "mytopic",
+    "mongodb.connection.uri": "mongodb://mongodb:27017/kafkaconnect?w=1&journal=true",
+    "mongodb.document.id.strategy": "at.grahsl.kafka.connect.mongodb.processor.id.strategy.PartialValueStrategy",
+    "mongodb.key.projection.list": "fieldA,fieldB",
+    "mongodb.key.projection.type": "whitelist",
+    "mongodb.collection": "mycollection",
+    "mongodb.replace.one.strategy":"at.grahsl.kafka.connect.mongodb.writemodel.filter.strategy.ReplaceOneBusinessKeyFilterStrategy"
+  }
+}
+```
+
+will eventually result in MongoDB documents looking like:
+
+```json
+{ 
+  "_id": ObjectId("5abf52cc97e51aae0679d237"),
+  "fieldA": "Anonymous", 
+  "fieldB": 42,
+  "active": true, 
+  "values": [12.34, 23.45, 34.56, 45.67]
+}
+```
+
+All upsert operations are done based on the unique business key which for this example is a compound one that consists of the two fields _(fieldA,fieldB)_. 
+
+NOTE: Future versions will allow to make use of arbitrary, individual strategies that can be registered and as used for the _mongodb.replace.one.strategy_ configuration setting.
+
 ### Change Data Capture Mode
 The sink connector can also be used in a different operation mode in order to handle change data capture (CDC) events. Currently, the following CDC events from [Debezium](http://debezium.io/) can be processed:
 
@@ -404,23 +472,24 @@ Data is written using acknowledged writes and the configured write concern level
 
 At the moment the following settings can be configured by means of the *connector.properties* file. For a config file containing default settings see [this example](https://github.com/hpgrahsl/kafka-connect-mongodb/blob/master/config/MongoDbSinkConnector.properties).
 
-| Name                                | Description                                                                            | Type    | Default                                                               | Valid Values                 | Importance |
-|-------------------------------------|----------------------------------------------------------------------------------------|---------|-----------------------------------------------------------------------|------------------------------|------------|
-| mongodb.collection                  | single sink collection name to write to                                                | string  | kafkatopic                                                            |                              | high       |
-| mongodb.connection.uri              | the mongodb connection URI as supported by the official drivers                        | string  | mongodb://localhost:27017/kafkaconnect?w=1&journal=true               |                              | high       |
-| mongodb.document.id.strategy        | class name of strategy to use for generating a unique document id (_id)                | string  | at.grahsl.kafka.connect.mongodb.processor.id.strategy.BsonOidStrategy |                              | high       |
-| mongodb.delete.on.null.values       | whether or not the connector tries to delete documents based on key when value is null | boolean | false                                                                 |                              | medium     |
-| mongodb.max.num.retries             | how often a retry should be done on write errors                                       | int     | 3                                                                     | [0,...]                      | medium     |
-| mongodb.retries.defer.timeout       | how long in ms a retry should get deferred                                             | int     | 5000                                                                  | [0,...]                      | medium     |
-| mongodb.change.data.capture.handler | class name of CDC handler to use for processing                                        | string  | ""                                                                    |                              | low        |
-| mongodb.document.id.strategies      | comma separated list of custom strategy classes to register for usage                  | string  | ""                                                                    |                              | low        |
-| mongodb.field.renamer.mapping       | inline JSON array with objects describing field name mappings (see docs)               | string  | []                                                                    |                              | low        |
-| mongodb.field.renamer.regexp        | inline JSON array with objects describing regexp settings (see docs)                   | string  | []                                                                    |                              | low        |
-| mongodb.key.projection.list         | comma separated list of field names for key projection                                 | string  | ""                                                                    |                              | low        |
-| mongodb.key.projection.type         | whether or not and which key projection to use                                         | string  | none                                                                  | [none, blacklist, whitelist] | low        |
-| mongodb.post.processor.chain        | comma separated list of post processor classes to build the chain with                 | string  | at.grahsl.kafka.connect.mongodb.processor.DocumentIdAdder             |                              | low        |
-| mongodb.value.projection.list       | comma separated list of field names for value projection                               | string  | ""                                                                    |                              | low        |
-| mongodb.value.projection.type       | whether or not and which value projection to use                                       | string  | none                                                                  | [none, blacklist, whitelist] | low        |
+| Name                                | Description                                                                            | Type    | Default                                                                                    | Valid Values                 | Importance |
+|-------------------------------------|----------------------------------------------------------------------------------------|---------|--------------------------------------------------------------------------------------------|------------------------------|------------|
+| mongodb.collection                  | single sink collection name to write to                                                | string  | kafkatopic                                                                                 |                              | high       |
+| mongodb.connection.uri              | the monogdb connection URI as supported by the offical drivers                         | string  | mongodb://localhost:27017/kafkaconnect?w=1&journal=true                                    |                              | high       |
+| mongodb.document.id.strategy        | class name of strategy to use for generating a unique document id (_id)                | string  | at.grahsl.kafka.connect.mongodb.processor.id.strategy.BsonOidStrategy                      |                              | high       |
+| mongodb.delete.on.null.values       | whether or not the connector tries to delete documents based on key when value is null | boolean | false                                                                                      |                              | medium     |
+| mongodb.max.num.retries             | how often a retry should be done on write errors                                       | int     | 3                                                                                          | [0,...]                      | medium     |
+| mongodb.retries.defer.timeout       | how long in ms a retry should get deferred                                             | int     | 5000                                                                                       | [0,...]                      | medium     |
+| mongodb.change.data.capture.handler | class name of CDC handler to use for processing                                        | string  | ""                                                                                         |                              | low        |
+| mongodb.document.id.strategies      | comma separated list of custom strategy classes to register for usage                  | string  | ""                                                                                         |                              | low        |
+| mongodb.field.renamer.mapping       | inline JSON array with objects describing field name mappings (see docs)               | string  | []                                                                                         |                              | low        |
+| mongodb.field.renamer.regexp        | inline JSON array with objects describing regexp settings (see docs)                   | string  | []                                                                                         |                              | low        |
+| mongodb.key.projection.list         | comma separated list of field names for key projection                                 | string  | ""                                                                                         |                              | low        |
+| mongodb.key.projection.type         | whether or not and which key projection to use                                         | string  | none                                                                                       | [none, blacklist, whitelist] | low        |
+| mongodb.post.processor.chain        | comma separated list of post processor classes to build the chain with                 | string  | at.grahsl.kafka.connect.mongodb.processor.DocumentIdAdder                                  |                              | low        |
+| mongodb.replace.one.strategy        | how to build the filter doc for the replaceOne write model                             | string  | at.grahsl.kafka.connect.mongodb.writemodel.filter.strategy.ReplaceOneDefaultFilterStrategy |                              | low        |
+| mongodb.value.projection.list       | comma separated list of field names for value projection                               | string  | ""                                                                                         |                              | low        |
+| mongodb.value.projection.type       | whether or not and which value projection to use                                       | string  | none                                                                                       | [none, blacklist, whitelist] | low        |
 
 ### Running in development
 

--- a/config/MongoDbSinkConnector.properties
+++ b/config/MongoDbSinkConnector.properties
@@ -42,3 +42,4 @@ mongodb.field.renamer.regexp=[]
 mongodb.post.processor.chain=at.grahsl.kafka.connect.mongodb.processor.DocumentIdAdder
 mongodb.change.data.capture.handler=
 mongodb.delete.on.null.values=false
+mongodb.replace.one.strategy=at.grahsl.kafka.connect.mongodb.writemodel.filter.strategy.ReplaceOneDefaultFilterStrategy

--- a/src/main/java/at/grahsl/kafka/connect/mongodb/MongoDbSinkConnectorConfig.java
+++ b/src/main/java/at/grahsl/kafka/connect/mongodb/MongoDbSinkConnectorConfig.java
@@ -26,6 +26,7 @@ import at.grahsl.kafka.connect.mongodb.processor.field.renaming.FieldnameMapping
 import at.grahsl.kafka.connect.mongodb.processor.field.renaming.RegExpSettings;
 import at.grahsl.kafka.connect.mongodb.processor.field.renaming.RenameByRegExp;
 import at.grahsl.kafka.connect.mongodb.processor.id.strategy.*;
+import at.grahsl.kafka.connect.mongodb.writemodel.filter.strategy.WriteModelFilterStrategy;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mongodb.MongoClientURI;
@@ -64,6 +65,7 @@ public class MongoDbSinkConnectorConfig extends AbstractConfig {
     public static final String MONGODB_POST_PROCESSOR_CHAIN_DEFAULT = "at.grahsl.kafka.connect.mongodb.processor.DocumentIdAdder";
     public static final String MONGODB_CHANGE_DATA_CAPTURE_HANDLER_DEFAULT = "";
     public static final boolean MONGODB_DELETE_ON_NULL_VALUES_DEFAULT = false;
+    public static final String MONGODB_REPLACE_ONE_STRATEGY_DEFAULT = "at.grahsl.kafka.connect.mongodb.writemodel.filter.strategy.ReplaceOneDefaultFilterStrategy";
 
     public static final String MONGODB_CONNECTION_URI_CONF = "mongodb.connection.uri";
     private static final String MONGODB_CONNECTION_URI_DOC = "the monogdb connection URI as supported by the offical drivers";
@@ -110,6 +112,9 @@ public class MongoDbSinkConnectorConfig extends AbstractConfig {
     public static final String MONGODB_DELETE_ON_NULL_VALUES = "mongodb.delete.on.null.values";
     private static final String MONGODB_DELETE_ON_NULL_VALUES_DOC = "whether or not the connector tries to delete documents based on key when value is null";
 
+    public static final String MONGODB_REPLACE_ONE_STRATEGY = "mongodb.replace.one.strategy";
+    private static final String MONGODB_REPLACE_ONE_STRATEGY_DOC = "how to build the filter doc for the replaceOne write model";
+
     private static ObjectMapper objectMapper = new ObjectMapper();
 
     public MongoDbSinkConnectorConfig(ConfigDef config, Map<String, String> parsedConfig) {
@@ -137,6 +142,7 @@ public class MongoDbSinkConnectorConfig extends AbstractConfig {
                 .define(MONGODB_POST_PROCESSOR_CHAIN, Type.STRING, MONGODB_POST_PROCESSOR_CHAIN_DEFAULT, Importance.LOW, MONGODB_POST_PROCESSOR_CHAIN_DOC)
                 .define(MONGODB_CHANGE_DATA_CAPTURE_HANDLER, Type.STRING, MONGODB_CHANGE_DATA_CAPTURE_HANDLER_DEFAULT, Importance.LOW, MONGODB_CHANGE_DATA_CAPTURE_HANDLER_DOC)
                 .define(MONGODB_DELETE_ON_NULL_VALUES, Type.BOOLEAN, MONGODB_DELETE_ON_NULL_VALUES_DEFAULT, Importance.MEDIUM, MONGODB_DELETE_ON_NULL_VALUES_DOC)
+                .define(MONGODB_REPLACE_ONE_STRATEGY, Type.STRING, MONGODB_REPLACE_ONE_STRATEGY_DEFAULT, Importance.LOW, MONGODB_REPLACE_ONE_STRATEGY_DOC)
                 ;
     }
 
@@ -308,6 +314,20 @@ public class MongoDbSinkConnectorConfig extends AbstractConfig {
 
     public boolean isDeleteOnNullValues() {
         return getBoolean(MONGODB_DELETE_ON_NULL_VALUES);
+    }
+
+    public WriteModelFilterStrategy getReplaceOneFilterStrategy() {
+        String replaceOneFilterStrategy = getString(MONGODB_REPLACE_ONE_STRATEGY);
+        try {
+            return (WriteModelFilterStrategy) Class.forName(replaceOneFilterStrategy)
+                                                        .getConstructor().newInstance();
+        } catch (ReflectiveOperationException e) {
+            throw new ConfigException(e.getMessage(),e);
+        } catch (ClassCastException e) {
+            throw new ConfigException("error: specified class "+ replaceOneFilterStrategy
+                    + " violates the contract since it doesn't implement " +
+                    WriteModelFilterStrategy.class);
+        }
     }
 
     public static Set<String> getPredefinedCdcHandlerClassNames() {

--- a/src/main/java/at/grahsl/kafka/connect/mongodb/writemodel/filter/strategy/DeleteOneDefaultFilterStrategy.java
+++ b/src/main/java/at/grahsl/kafka/connect/mongodb/writemodel/filter/strategy/DeleteOneDefaultFilterStrategy.java
@@ -1,0 +1,23 @@
+package at.grahsl.kafka.connect.mongodb.writemodel.filter.strategy;
+
+import at.grahsl.kafka.connect.mongodb.converter.SinkDocument;
+import com.mongodb.DBCollection;
+import com.mongodb.client.model.DeleteOneModel;
+import com.mongodb.client.model.WriteModel;
+import org.apache.kafka.connect.errors.DataException;
+import org.bson.BsonDocument;
+
+public class DeleteOneDefaultFilterStrategy implements WriteModelFilterStrategy {
+
+    @Override
+    public WriteModel<BsonDocument> createWriteModel(SinkDocument document) {
+
+        BsonDocument kd = document.getKeyDoc().orElseThrow(
+                () -> new DataException("error: cannot build the WriteModel since"
+                        + " the key document was missing unexpectedly")
+        );
+
+        return  new DeleteOneModel<>(new BsonDocument(DBCollection.ID_FIELD_NAME, kd));
+
+    }
+}

--- a/src/main/java/at/grahsl/kafka/connect/mongodb/writemodel/filter/strategy/ReplaceOneBusinessKeyFilterStrategy.java
+++ b/src/main/java/at/grahsl/kafka/connect/mongodb/writemodel/filter/strategy/ReplaceOneBusinessKeyFilterStrategy.java
@@ -1,0 +1,38 @@
+package at.grahsl.kafka.connect.mongodb.writemodel.filter.strategy;
+
+import at.grahsl.kafka.connect.mongodb.converter.SinkDocument;
+import com.mongodb.DBCollection;
+import com.mongodb.client.model.ReplaceOneModel;
+import com.mongodb.client.model.UpdateOptions;
+import com.mongodb.client.model.WriteModel;
+import org.apache.kafka.connect.errors.DataException;
+import org.bson.BsonDocument;
+import org.bson.BsonValue;
+
+public class ReplaceOneBusinessKeyFilterStrategy implements WriteModelFilterStrategy {
+
+    private static final UpdateOptions UPDATE_OPTIONS =
+                                    new UpdateOptions().upsert(true);
+
+    @Override
+    public WriteModel<BsonDocument> createWriteModel(SinkDocument document) {
+
+        BsonDocument vd = document.getValueDoc().orElseThrow(
+                () -> new DataException("error: cannot build the WriteModel since"
+                        + " the value document was missing unexpectedly")
+        );
+
+        BsonValue businessKey = vd.get(DBCollection.ID_FIELD_NAME);
+
+        if(businessKey == null || !(businessKey instanceof BsonDocument)) {
+            throw new DataException("error: cannot build the WriteModel since"
+                    + " the value document does not contain an _id field of type BsonDocument"
+                    + " which holds the business key fields");
+        }
+
+        vd.remove(DBCollection.ID_FIELD_NAME);
+
+        return new ReplaceOneModel<>((BsonDocument)businessKey, vd, UPDATE_OPTIONS);
+
+    }
+}

--- a/src/main/java/at/grahsl/kafka/connect/mongodb/writemodel/filter/strategy/ReplaceOneDefaultFilterStrategy.java
+++ b/src/main/java/at/grahsl/kafka/connect/mongodb/writemodel/filter/strategy/ReplaceOneDefaultFilterStrategy.java
@@ -1,0 +1,31 @@
+package at.grahsl.kafka.connect.mongodb.writemodel.filter.strategy;
+
+import at.grahsl.kafka.connect.mongodb.converter.SinkDocument;
+import com.mongodb.DBCollection;
+import com.mongodb.client.model.ReplaceOneModel;
+import com.mongodb.client.model.UpdateOptions;
+import com.mongodb.client.model.WriteModel;
+import org.apache.kafka.connect.errors.DataException;
+import org.bson.BsonDocument;
+
+public class ReplaceOneDefaultFilterStrategy implements WriteModelFilterStrategy {
+
+    private static final UpdateOptions UPDATE_OPTIONS =
+                                    new UpdateOptions().upsert(true);
+
+    @Override
+    public WriteModel<BsonDocument> createWriteModel(SinkDocument document) {
+
+        BsonDocument vd = document.getValueDoc().orElseThrow(
+                () -> new DataException("error: cannot build the WriteModel since"
+                        + " the value document was missing unexpectedly")
+        );
+
+        return new ReplaceOneModel<>(
+                new BsonDocument(DBCollection.ID_FIELD_NAME,
+                        vd.get(DBCollection.ID_FIELD_NAME)),
+                vd,
+                UPDATE_OPTIONS);
+
+    }
+}

--- a/src/main/java/at/grahsl/kafka/connect/mongodb/writemodel/filter/strategy/WriteModelFilterStrategy.java
+++ b/src/main/java/at/grahsl/kafka/connect/mongodb/writemodel/filter/strategy/WriteModelFilterStrategy.java
@@ -1,0 +1,11 @@
+package at.grahsl.kafka.connect.mongodb.writemodel.filter.strategy;
+
+import at.grahsl.kafka.connect.mongodb.converter.SinkDocument;
+import com.mongodb.client.model.WriteModel;
+import org.bson.BsonDocument;
+
+public interface WriteModelFilterStrategy {
+
+    WriteModel<BsonDocument> createWriteModel(SinkDocument document);
+
+}

--- a/src/test/java/at/grahsl/kafka/connect/mongodb/writemodel/filter/strategy/WriteModelFilterStrategyTest.java
+++ b/src/test/java/at/grahsl/kafka/connect/mongodb/writemodel/filter/strategy/WriteModelFilterStrategyTest.java
@@ -1,0 +1,188 @@
+package at.grahsl.kafka.connect.mongodb.writemodel.filter.strategy;
+
+import at.grahsl.kafka.connect.mongodb.converter.SinkDocument;
+import com.mongodb.DBCollection;
+import com.mongodb.client.model.DeleteOneModel;
+import com.mongodb.client.model.ReplaceOneModel;
+import com.mongodb.client.model.WriteModel;
+import org.apache.kafka.connect.errors.DataException;
+import org.bson.BsonBoolean;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class WriteModelFilterStrategyTest {
+
+    public static final DeleteOneDefaultFilterStrategy DELETE_ONE_DEFAULT_FILTER_STRATEGY =
+            new DeleteOneDefaultFilterStrategy();
+
+    public static final ReplaceOneDefaultFilterStrategy REPLACE_ONE_DEFAULT_FILTER_STRATEGY =
+            new ReplaceOneDefaultFilterStrategy();
+
+    public static final ReplaceOneBusinessKeyFilterStrategy REPLACE_ONE_BUSINESS_KEY_FILTER_STRATEGY =
+            new ReplaceOneBusinessKeyFilterStrategy();
+
+    public static final BsonDocument FILTER_DOC_DELETE_DEFAULT = new BsonDocument(DBCollection.ID_FIELD_NAME,
+            new BsonDocument("id",new BsonInt32(1004)));
+
+    public static final BsonDocument FILTER_DOC_REPLACE_DEFAULT =
+            new BsonDocument(DBCollection.ID_FIELD_NAME,new BsonInt32(1004));
+
+    public static final BsonDocument REPLACEMENT_DOC_DEFAULT =
+            new BsonDocument(DBCollection.ID_FIELD_NAME,new BsonInt32(1004))
+                    .append("first_name",new BsonString("Anne"))
+                    .append("last_name",new BsonString("Kretchmar"))
+                    .append("email",new BsonString("annek@noanswer.org"));
+
+    public static final BsonDocument FILTER_DOC_REPLACE_BUSINESS_KEY =
+            new BsonDocument("first_name",new BsonString("Anne"))
+                    .append("last_name",new BsonString("Kretchmar"));
+
+    public static final BsonDocument REPLACEMENT_DOC_BUSINESS_KEY =
+            new BsonDocument("first_name",new BsonString("Anne"))
+                    .append("last_name",new BsonString("Kretchmar"))
+                    .append("email",new BsonString("annek@noanswer.org"))
+                    .append("age", new BsonInt32(23))
+                    .append("active", new BsonBoolean(true));
+
+    @Test
+    @DisplayName("when key document is missing for DeleteOneDefaultFilterStrategy then DataException")
+    public void testDeleteOneDefaultFilterStrategyWithMissingKeyDocument() {
+
+        assertThrows(DataException.class,() ->
+                DELETE_ONE_DEFAULT_FILTER_STRATEGY.createWriteModel(
+                        new SinkDocument(null, new BsonDocument())
+                )
+        );
+
+    }
+
+    @Test
+    @DisplayName("when sink document is valid for DeleteOneDefaultFilterStrategy then correct DeleteOneModel")
+    public void testDeleteOneDefaultFilterStrategyWitValidSinkDocument() {
+
+        BsonDocument keyDoc = new BsonDocument("id",new BsonInt32(1004));
+
+        WriteModel<BsonDocument> result =
+                DELETE_ONE_DEFAULT_FILTER_STRATEGY.createWriteModel(new SinkDocument(keyDoc,null));
+
+        assertTrue(result instanceof DeleteOneModel,
+                () -> "result expected to be of type DeleteOneModel");
+
+        DeleteOneModel<BsonDocument> writeModel =
+                (DeleteOneModel<BsonDocument>) result;
+
+        assertTrue(writeModel.getFilter() instanceof BsonDocument,
+                () -> "filter expected to be of type BsonDocument");
+
+        assertEquals(FILTER_DOC_DELETE_DEFAULT,writeModel.getFilter());
+
+    }
+
+    @Test
+    @DisplayName("when value document is missing for ReplaceOneDefaultFilterStrategy then DataException")
+    public void testReplaceOneDefaultFilterStrategyWithMissingValueDocument() {
+
+        assertThrows(DataException.class,() ->
+                REPLACE_ONE_DEFAULT_FILTER_STRATEGY.createWriteModel(
+                        new SinkDocument(new BsonDocument(), null)
+                )
+        );
+
+    }
+
+    @Test
+    @DisplayName("when sink document is valid for ReplaceOneDefaultFilterStrategy then correct ReplaceOneModel")
+    public void testReplaceOneDefaultFilterStrategyWitValidSinkDocument() {
+
+        BsonDocument valueDoc = new BsonDocument(DBCollection.ID_FIELD_NAME,new BsonInt32(1004))
+                .append("first_name",new BsonString("Anne"))
+                .append("last_name",new BsonString("Kretchmar"))
+                .append("email",new BsonString("annek@noanswer.org"));
+
+        WriteModel<BsonDocument> result =
+                REPLACE_ONE_DEFAULT_FILTER_STRATEGY.createWriteModel(new SinkDocument(null,valueDoc));
+
+        assertTrue(result instanceof ReplaceOneModel,
+                () -> "result expected to be of type ReplaceOneModel");
+
+        ReplaceOneModel<BsonDocument> writeModel =
+                (ReplaceOneModel<BsonDocument>) result;
+
+        assertEquals(REPLACEMENT_DOC_DEFAULT,writeModel.getReplacement(),
+                ()-> "replacement doc not matching what is expected");
+
+        assertTrue(writeModel.getFilter() instanceof BsonDocument,
+                () -> "filter expected to be of type BsonDocument");
+
+        assertEquals(FILTER_DOC_REPLACE_DEFAULT,writeModel.getFilter());
+
+        assertTrue(writeModel.getOptions().isUpsert(),
+                () -> "replacement expected to be done in upsert mode");
+
+    }
+
+    @Test
+    @DisplayName("when value document is missing for ReplaceOneBusinessKeyFilterStrategy then DataException")
+    public void testReplaceOneBusinessKeyFilterStrategyWithMissingValueDocument() {
+
+        assertThrows(DataException.class,() ->
+                REPLACE_ONE_BUSINESS_KEY_FILTER_STRATEGY.createWriteModel(
+                        new SinkDocument(new BsonDocument(), null)
+                )
+        );
+
+    }
+
+    @Test
+    @DisplayName("when value document is missing an _id field for ReplaceOneBusinessKeyFilterStrategy then DataException")
+    public void testReplaceOneBusinessKeyFilterStrategyWithMissingIdFieldInValueDocument() {
+
+        assertThrows(DataException.class,() ->
+                REPLACE_ONE_BUSINESS_KEY_FILTER_STRATEGY.createWriteModel(
+                        new SinkDocument(new BsonDocument(), new BsonDocument())
+                )
+        );
+
+    }
+
+    @Test
+    @DisplayName("when sink document is valid for ReplaceOneBusinessKeyFilterStrategy then correct ReplaceOneModel")
+    public void testReplaceOneBusinessKeyFilterStrategyWitValidSinkDocument() {
+
+        BsonDocument valueDoc = new BsonDocument(DBCollection.ID_FIELD_NAME,
+                new BsonDocument("first_name",new BsonString("Anne"))
+                        .append("last_name",new BsonString("Kretchmar")))
+                .append("first_name",new BsonString("Anne"))
+                .append("last_name",new BsonString("Kretchmar"))
+                .append("email",new BsonString("annek@noanswer.org"))
+                .append("age", new BsonInt32(23))
+                .append("active", new BsonBoolean(true));
+
+        WriteModel<BsonDocument> result =
+                REPLACE_ONE_BUSINESS_KEY_FILTER_STRATEGY.createWriteModel(new SinkDocument(null,valueDoc));
+
+        assertTrue(result instanceof ReplaceOneModel,
+                () -> "result expected to be of type ReplaceOneModel");
+
+        ReplaceOneModel<BsonDocument> writeModel =
+                (ReplaceOneModel<BsonDocument>) result;
+
+        assertEquals(REPLACEMENT_DOC_BUSINESS_KEY,writeModel.getReplacement(),
+                ()-> "replacement doc not matching what is expected");
+
+        assertTrue(writeModel.getFilter() instanceof BsonDocument,
+                () -> "filter expected to be of type BsonDocument");
+
+        assertEquals(FILTER_DOC_REPLACE_BUSINESS_KEY,writeModel.getFilter());
+
+        assertTrue(writeModel.getOptions().isUpsert(),
+                () -> "replacement expected to be done in upsert mode");
+
+    }
+
+}


### PR DESCRIPTION
* add feature to be able to configure filter document for replace one model

introduced a write model filter strategy to be able to support different use cases. besides the default option there is now a new filter strategy which allows to work with unique business keys and still have e.g. a mongodb ObjectId inserted once during the first upsert per document. this strategy only leads to a correct behaviour in case the business key fields (expressed by means of the PartialValueStrategy for the _id field) are guaranteed to be unique in the original kafka records.

see config option mongodb.replace.one.strategy with two pre-defined strategy options
- at.grahsl.kafka.connect.mongodb.writemodel.filter.strategy.ReplaceOneDefaultFilterStrategy
- at.grahsl.kafka.connect.mongodb.writemodel.filter.strategy.ReplaceOneBusinessKeyFilterStrategy

* document new feature allowing to configure write model filters

* add basic unit tests for write model strategies

* fix delete one model default strategy